### PR TITLE
Fix snappy installation with optional dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,13 +70,7 @@ async function create(directory) {
 	}
 
 	try {
-		await execa('npm', ['install', 'directus', '--production', '--no-optional'], {
-			cwd: rootPath,
-			stdin: 'ignore',
-		});
-
-		// ensure snappy installs it's optional dependencies which includes platform-specific binary
-		await execa('npm', ['install', 'snappy'], {
+		await execa('npm', ['install', 'directus', '--production'], {
 			cwd: rootPath,
 			stdin: 'ignore',
 		});

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,6 +74,12 @@ async function create(directory) {
 			cwd: rootPath,
 			stdin: 'ignore',
 		});
+
+		// ensure snappy installs it's optional dependencies which includes platform-specific binary
+		await execa('npm', ['install', 'snappy'], {
+			cwd: rootPath,
+			stdin: 'ignore',
+		});
 	} catch (err) {
 		spinner.fail();
 		// eslint-disable-next-line no-console


### PR DESCRIPTION
Fixes directus/create-directus-project#2

**Note:** I'm not sure if there's actually a better solution (if there is, do feel free to close this).

---

I believe the issue stems from the `--no-optional` flag during the installation here:

https://github.com/directus/create-directus-project/blob/01ce68a095f6afee4471cd671aaf4474a0d6176a/lib/index.js#L73

which gets propagated to the `snappy` package and causes it not to install it's optional dependencies which include platform-specific binary, thus breaking the `create-directus-project` cli:

![image](https://user-images.githubusercontent.com/42867097/183347416-a2890e33-6665-4a5e-8b67-d9c6a60845e1.png)

This is further confirmed by https://github.com/directus/create-directus-project/issues/2 where running `npm install directus` manually works, since there is no `--no-optional` flag being used.