### PR TITLE
Enhance output format

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+	"htmlWhitespaceSensitivity": "ignore",
+	"printWidth": 120,
+	"singleQuote": true,
+	"useTabs": true,
+	"proseWrap": "always"
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ const chalk = require('chalk');
 const fse = require('fs-extra');
 const execa = require('execa');
 const ora = require('ora');
+const logSymbols = require('log-symbols');
 
 const pkg = require('../package.json');
 const checkRequirements = require('./check-requirements');
@@ -30,16 +31,14 @@ async function create(directory) {
 		const stat = await fse.stat(rootPath);
 
 		if (stat.isDirectory() === false) {
-			// eslint-disable-next-line no-console
-			console.log(`Destination ${chalk.red(directory)} already exists and is not a directory.`);
+			console.error(`Destination '${chalk.blue(directory)}' already exists and is not a directory.`);
 			process.exit(1);
 		}
 
 		const files = await fse.readdir(rootPath);
 
 		if (files.length > 0) {
-			// eslint-disable-next-line no-console
-			console.log(`Destination ${chalk.red(directory)} already exists and is not an empty directory.`);
+			console.error(`Destination '${chalk.blue(directory)}' already exists and is not an empty directory.`);
 			process.exit(1);
 		}
 	} else {
@@ -55,7 +54,34 @@ async function create(directory) {
 		await fse.mkdir(path.join(rootPath, 'extensions', folderName));
 	}
 
-	const spinner = ora('Installing Directus').start();
+	// Let's get into the Directus mood while waiting
+	const bunnyFrames = [];
+	const numOfSpaces = 3;
+	for (let i = 0; i < numOfSpaces + 1; i++) {
+		bunnyFrames[i] = ' '.repeat(i) + '🐰' + ' '.repeat(numOfSpaces - i);
+	}
+	bunnyFrames.push(...bunnyFrames.slice(1, -1).reverse());
+	const spinner = ora({
+		spinner: {
+			interval: 520,
+			frames: bunnyFrames,
+		},
+	});
+
+	spinner.start(chalk.bold('Installing Directus'));
+
+	const onError = ({ err, symbol = 'error', text, exit = true }) => {
+		spinner.stopAndPersist({
+			symbol: logSymbols[symbol] + ' '.repeat(numOfSpaces + 1),
+			text: text ? chalk.bold(text) : undefined,
+		});
+		if (err) {
+			console.error(err.stderr || err.stdout || 'Unknown error');
+		}
+		if (exit) {
+			process.exit(1);
+		}
+	};
 
 	try {
 		await execa('npm', ['init', '-y'], {
@@ -63,10 +89,7 @@ async function create(directory) {
 			stdin: 'ignore',
 		});
 	} catch (err) {
-		spinner.fail();
-		// eslint-disable-next-line no-console
-		console.log(`Error: ${err.stderr}`);
-		process.exit(1);
+		onError({ err });
 	}
 
 	try {
@@ -75,10 +98,7 @@ async function create(directory) {
 			stdin: 'ignore',
 		});
 	} catch (err) {
-		spinner.fail();
-		// eslint-disable-next-line no-console
-		console.log(`Error: ${err.stderr}`);
-		process.exit(1);
+		onError({ err });
 	}
 
 	spinner.stop();
@@ -89,30 +109,23 @@ async function create(directory) {
 			stdio: 'inherit',
 		});
 	} catch (err) {
-		spinner.fail();
-		// eslint-disable-next-line no-console
-		console.log(`Error: ${err.stderr}`);
-		process.exit(1);
+		onError({ text: 'Error while initializing the project' });
 	}
-
-	let update;
 
 	try {
-		update = await checkForUpdate(pkg);
+		const update = await checkForUpdate(pkg);
+		if (update) {
+			console.log();
+			console.log(chalk.yellow.bold(`A new version of \`${pkg.name}\` is available!`));
+			console.log('You can update by running: ' + chalk.cyan(`npm i -g ${pkg.name}@latest`));
+			console.log();
+		}
 	} catch (err) {
-		// eslint-disable-next-line no-console
-		console.log(`Error: ${err.stderr}`);
-	}
-
-	if (update) {
-		// eslint-disable-next-line no-console
-		console.log();
-		// eslint-disable-next-line no-console
-		console.log(chalk.yellow.bold(`A new version of \`${pkg.name}\` is available!`));
-		// eslint-disable-next-line no-console
-		console.log('You can update by running: ' + chalk.cyan(`npm i -g ${pkg.name}@latest`));
-		// eslint-disable-next-line no-console
-		console.log();
+		onError({
+			symbol: 'warning',
+			exit: false,
+			text: `Error while checking for newer version of \`${pkg.name}\``,
+		});
 	}
 
 	process.exit(0);

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
 		"commander": "^8.0.0",
 		"execa": "^5.1.1",
 		"fs-extra": "^10.0.0",
+		"log-symbols": "4.1.0",
 		"ora": "^5.4.0",
 		"update-check": "^1.5.4"
-	},
-	"gitHead": "24621f3934dc77eb23441331040ed13c676ceffd"
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ specifiers:
   commander: ^8.0.0
   execa: ^5.1.1
   fs-extra: ^10.0.0
+  log-symbols: 4.1.0
   ora: ^5.4.0
   update-check: ^1.5.4
 
@@ -13,6 +14,7 @@ dependencies:
   commander: 8.3.0
   execa: 5.1.1
   fs-extra: 10.1.0
+  log-symbols: 4.1.0
   ora: 5.4.1
   update-check: 1.5.4
 


### PR DESCRIPTION
Inspired by https://github.com/directus/directus/discussions/16588.

When a failing command reports errors on `stdout` those lines are swallowed by `create-directus-project` and the user might get an unmeaningful message instead:
```
✖ Installing Directus
Error: undefined
```

Now, `create-directus-project` prints errors reported on `stdout` if `stderr` is empty and in case nothing should be reported at all, it fall backs to "Unknown error".

Also adding clearer messages for initialization / update check errors and trying to sweeten the waiting time a bit with a more interesting spinner 😃 
